### PR TITLE
Handle quoted GET params in mapping template

### DIFF
--- a/humilis_kinesis_proxy/__init__.py
+++ b/humilis_kinesis_proxy/__init__.py
@@ -1,5 +1,5 @@
 """Humilis plug-in to deploy an AWS API Gateway proxy to AWS Kinesis."""
 
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "German Gomez-Herrero, FindHotel BV"

--- a/humilis_kinesis_proxy/resources.yaml.j2
+++ b/humilis_kinesis_proxy/resources.yaml.j2
@@ -177,10 +177,10 @@ resources:
                       #set($payload = $payload + ',')
                       #end
                       #end
-                      #set($payload = $payload + '}')
+                      #set($payload = $payload.replaceAll("\\'","'") + '}')
                       { 
                          "Data": "$util.base64Encode($payload)",
-                         "PartitionKey": "{{resource.partition_key or partition_key or 10|uuid4}}"
+                         "PartitionKey": "$context.requestId"
                       }
                    ],
                    "StreamName": "{{resource.path.stream_name or stream_name}}"


### PR DESCRIPTION
Fixes two things:

* Quoted GET parameters were not being escaped correctly.
* Uses the request ID as distribution key instead of having a fixed value: it will lead to events being distributed across Kinesis shards evenly.